### PR TITLE
Add 'nsuiImage' attribute to ImageRenderer

### DIFF
--- a/Sources/NSUI/Image.swift
+++ b/Sources/NSUI/Image.swift
@@ -16,6 +16,18 @@ extension Image {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, *)
+extension ImageRenderer {
+    @MainActor
+    public var nsuiImage: NSUIImage? {
+        #if canImport(AppKit)
+        return nsImage
+        #elseif canImport(UIKit)
+        return uiImage
+        #endif
+    }
+}
+
 #if canImport(AppKit)
 extension NSImage {
     public var cgImage: CGImage? {

--- a/Sources/NSUI/Image.swift
+++ b/Sources/NSUI/Image.swift
@@ -16,7 +16,7 @@ extension Image {
     }
 }
 
-@available(iOS 16.0, macOS 13.0, *)
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension ImageRenderer {
     @MainActor
     public var nsuiImage: NSUIImage? {


### PR DESCRIPTION
ImageRenderer was added in iOS 16/macOS 13 and it lets us turn any SwiftUI view into an image:
![Screenshot 2023-11-20 at 7 02 13 AM](https://github.com/mattmassicotte/nsui/assets/1857338/e44b1a40-d23b-4f53-8147-65fedc32d2dd)
As it provides separate properties for `NSImage` and `UIImage`, I found myself wanting to push the hashtag conditionals out of my (eventually) multi-platform app and down into here. 🥰

I'm not entirely sure that `Image.swift` is the "correct" place to put this, but adding a new file felt a bit extraneous for code that's shorter than its own PR verbiage.

Cheers