### PR TITLE
Add separatorColor alias

### DIFF
--- a/Sources/NSUI/Color.swift
+++ b/Sources/NSUI/Color.swift
@@ -18,5 +18,8 @@ extension NSColor {
 
 	/// Alias for `windowBackgroundColor` on macOS.
 	public static let systemBackground = windowBackgroundColor
+
+	/// Alias for `separatorColor` on macOS.
+	public static let separator = separatorColor
 }
 #endif


### PR DESCRIPTION
iOS has `UIColor.separator` while macOS has `NSColor.separatorColor`